### PR TITLE
fix: wrap and break coupon code on order summary and coupon popup

### DIFF
--- a/public/scss/components/OrderSummary.module.scss
+++ b/public/scss/components/OrderSummary.module.scss
@@ -127,6 +127,8 @@
 {
   @extend .voucherButton;
   position: relative;
+  height: fit-content;
+  padding: 10px 16px;
 
   &[data-identity="ordersummary-points-btn"]
   {
@@ -168,8 +170,11 @@
   @extend .voucherText;
   @include RegulerSemiBold;
   @include truncate(1);
-  max-width: 60%;
+  max-width: 65%;
   color: $color_black;
+  display: block;
+  word-wrap: break-word;
+  word-break: break-all;
 }
 
 .registerNow

--- a/public/scss/components/PopUpVoucherCoupon.module.scss
+++ b/public/scss/components/PopUpVoucherCoupon.module.scss
@@ -194,8 +194,8 @@
 
 .voucherDetailCode
 {
-  @include flex(row, center, flex-start);
   @include ExtraSmallReguler;
+  display: inline-block;
   color: $color_text_secondary;
   
   & > span
@@ -203,6 +203,7 @@
     @include SmallSmall;
     color: $color_blue;
     margin-left: 5px;
+    word-break: break-all;
 
     svg
     {


### PR DESCRIPTION
![desktop coupon](https://user-images.githubusercontent.com/55394860/171135494-d639cdba-bcbd-479e-ae33-a0887c3affa3.png)
![desktop coupon popup](https://user-images.githubusercontent.com/55394860/171135512-d28d5403-2939-4f7c-a362-4aaea02911a8.png)
![mobile coupon](https://user-images.githubusercontent.com/55394860/171135508-f80bf564-ef20-4a43-a3dd-2f1065339d5b.png)
![mobile coupon popup](https://user-images.githubusercontent.com/55394860/171135503-9df012ff-b163-43ea-b850-0c5c5336958d.png)
