### PR TITLE
fix(products): adjust image for safari macos 10.15

### DIFF
--- a/public/scss/components/Products.module.scss
+++ b/public/scss/components/Products.module.scss
@@ -68,7 +68,6 @@
   
   &_productImageContainer
   {
-    display: flex;
     height: fit-content;
     position: relative;
 


### PR DESCRIPTION
before
<img width="1280" alt="Screen Shot 2022-07-06 at 15 48 33" src="https://user-images.githubusercontent.com/43097333/177512203-f9e15fd2-09f8-4a08-8be3-497f5b2d6ddb.png">

after:
<img width="1280" alt="Screen Shot 2022-07-06 at 15 51 07" src="https://user-images.githubusercontent.com/43097333/177512231-4da291e2-c3fc-451c-a54e-11cf0f3f3b5e.png">

