### PR TITLE
fix: product category image stretch

### DIFF
--- a/public/scss/components/ProductCategory.module.scss
+++ b/public/scss/components/ProductCategory.module.scss
@@ -150,7 +150,7 @@
   {
     visibility: hidden;
     width: 100%;
-    height: 265px;
+    height: auto;
   }
 
   &_item,

--- a/public/scss/components/ProductCategory.module.scss
+++ b/public/scss/components/ProductCategory.module.scss
@@ -151,6 +151,8 @@
     visibility: hidden;
     width: 100%;
     height: auto;
+    max-height: 265px;
+    object-fit: cover;
   }
 
   &_item,


### PR DESCRIPTION
```
catatan dari designer:
- widthnya di 100% in (tetap full)
- heightnya lepas saja
- new update dari desainer berubah jadinya: dikasih max-height, dipotong gambar user (kalau potrait or square)
- kalau gambarnya dipotong, itu resikonya soalnya sudah dikasih guideline rekomendasinya bagaimana (3:1 / 1280x470)
- mobile memang tidak ada gambar
- yang penting gak gepeng lagi
```

Kalau ada IG Feed (gak full category + gambarnya kotak --> dipotong)
<img width="960" alt="image" src="https://user-images.githubusercontent.com/45808774/179953701-060083c5-51d7-4643-b0a4-ecb8d187ced6.png">

Ada IG feed (gak full category + gambar tjakep)
<img width="960" alt="image" src="https://user-images.githubusercontent.com/45808774/179953973-d28eb50c-5092-4366-81f1-6802cb8f90e3.png">

https://user-images.githubusercontent.com/45808774/179954253-816e15bc-c482-438e-9fc6-46a05e255807.mp4


