### PR TITLE
fix: swap thumbor width for desktop & mobile

### DIFF
--- a/components/Widget/MainAdvertisement.tsx
+++ b/components/Widget/MainAdvertisement.tsx
@@ -27,7 +27,7 @@ const MainAdvertisement: FC = () => {
           </div>
         }
         thumborSetting={{
-          width: size.width < 575 ? 800 : 400,
+          width: size.width < 575 ? 400 : 800,
           format: "webp",
           quality: 95,
         }}


### PR DESCRIPTION
Task: https://phabricator.sirclo.com/T36690

![urban thumbor desktop](https://user-images.githubusercontent.com/55394860/186372680-391101f1-86e5-4fd5-8085-7f023bef2a3b.png)
![urban thumbor mobile](https://user-images.githubusercontent.com/55394860/186372690-16779491-863e-443d-83bd-ff9fa05776d7.png)

