### PR TITLE
fix: image slider blur and remove space on slider banner

### DIFF
--- a/components/Banner/index.tsx
+++ b/components/Banner/index.tsx
@@ -5,7 +5,8 @@ import {
   useEffect
 } from 'react'
 import { Banner } from '@sirclo/nexus'
-import Carousel from '@brainhubeu/react-carousel'
+// import Carousel from '@brainhubeu/react-carousel'
+import Slider from 'react-slick'
 /* component library */
 import useWindowSize from 'lib/useWindowSize'
 import { useBannerSize } from 'lib/useBannerSize'
@@ -32,17 +33,23 @@ const BannerComponent: FC<any> = ({ dataBanners }) => {
   }, [isReady])
 
   return (
-    <div className={styleBanner.container}>
+    <div className={styleBanner.bannerCarousel}>
       <Banner
-        Carousel={Carousel}
-        autoPlay={isReady ? 5000 : null}
         data={dataBanners?.data}
-        infinite
+        Carousel={Slider}
         classes={classesBanner}
+        lazyLoadedImage={false}
+        autoplay={true}
+        autoplaySpeed={5000}
+        arrows={false}
+        infinite={true}
+        slidesToShow={1}
+        slidesToScroll={1}
+        adaptiveHeight={true}
         thumborSetting={{
           width: useBannerSize(size.width),
-          format: 'webp',
-          quality: 95
+          format: "webp",
+          quality: 85,
         }}
         loadingComponent={
           <Placeholder classes={placeholder} withImage />

--- a/components/Banner/index.tsx
+++ b/components/Banner/index.tsx
@@ -32,7 +32,7 @@ const BannerComponent: FC<any> = ({ dataBanners }) => {
   }, [isReady])
 
   return (
-    <div className={styleBanner.bannerCarousel}>
+    <div className={styleBanner.container}>
       <Banner
         data={dataBanners?.data}
         Carousel={Slider}

--- a/components/Banner/index.tsx
+++ b/components/Banner/index.tsx
@@ -47,7 +47,7 @@ const BannerComponent: FC<any> = ({ dataBanners }) => {
         adaptiveHeight={true}
         thumborSetting={{
           width: useBannerSize(size.width),
-          format: "webp",
+          format: 'webp',
           quality: 95,
         }}
         loadingComponent={

--- a/components/Banner/index.tsx
+++ b/components/Banner/index.tsx
@@ -5,7 +5,6 @@ import {
   useEffect
 } from 'react'
 import { Banner } from '@sirclo/nexus'
-// import Carousel from '@brainhubeu/react-carousel'
 import Slider from 'react-slick'
 /* component library */
 import useWindowSize from 'lib/useWindowSize'
@@ -49,7 +48,7 @@ const BannerComponent: FC<any> = ({ dataBanners }) => {
         thumborSetting={{
           width: useBannerSize(size.width),
           format: "webp",
-          quality: 85,
+          quality: 95,
         }}
         loadingComponent={
           <Placeholder classes={placeholder} withImage />

--- a/components/Instafeed/index.tsx
+++ b/components/Instafeed/index.tsx
@@ -1,7 +1,6 @@
 /* library package */
 import { FC, useState } from 'react'
 import { InstagramFeed } from '@sirclo/nexus'
-// import Carousel from '@brainhubeu/react-carousel'
 import Slider from 'react-slick'
 
 /* library template */
@@ -13,6 +12,7 @@ import EmptyComponent from 'components/EmptyComponent/EmptyComponent'
 
 /* styles */
 import styles from 'public/scss/components/InstaFeed.module.scss'
+import { useBannerSize } from 'lib/useBannerSize'
 
 const classesInstagramFeed = {
   containerClassName: styles.instagramFeed,
@@ -78,9 +78,9 @@ const Instafeed: FC<InstafeedType> = ({
           </div>
         }
         thumborSetting={{
-          width: size.width < 575 ? 250 : 400,
+          width: useBannerSize(size.width),
           format: 'webp',
-          quality: 85,
+          quality: 95,
         }}
       />
     </>

--- a/components/Instafeed/index.tsx
+++ b/components/Instafeed/index.tsx
@@ -1,7 +1,8 @@
 /* library package */
 import { FC, useState } from 'react'
 import { InstagramFeed } from '@sirclo/nexus'
-import Carousel from '@brainhubeu/react-carousel'
+// import Carousel from '@brainhubeu/react-carousel'
+import Slider from 'react-slick'
 
 /* library template */
 import useWindowSize from 'lib/useWindowSize'
@@ -64,7 +65,7 @@ const Instafeed: FC<InstafeedType> = ({
       <InstagramFeed
         postLimit={6}
         classes={classesInstagramFeed}
-        Carousel={size.width <= 765 && Carousel}
+        Carousel={size.width <= 765 && Slider}
         emptyStateComponent={EmptyComponent}
         getReturnedMediaCount={(mediaCount: number) => setTotalPost(mediaCount)}
         loadingComponent={

--- a/components/Testimonial/TestimonialSlider.tsx
+++ b/components/Testimonial/TestimonialSlider.tsx
@@ -1,6 +1,7 @@
 import { FC, useState } from 'react'
 import { Testimonials, isTestimonialAllowed } from '@sirclo/nexus'
-import Carousel from '@brainhubeu/react-carousel'
+// import Carousel from '@brainhubeu/react-carousel'
+import Slider from 'react-slick'
 import Placeholder from 'components/Placeholder'
 
 /* style */
@@ -34,7 +35,7 @@ const TestimonialSlider: FC<any> = () => {
       {(pageInfo.totalItems === null || pageInfo.totalItems > 0) &&
         testimonialAllowed &&
         <Testimonials
-          Carousel={Carousel}
+          Carousel={Slider}
           classes={classesTestimonials}
           arrowLeft={<div className={style.arrowLeft}></div>}
           arrowRight={<div className={style.arrowRight}></div>}

--- a/components/Testimonial/TestimonialSlider.tsx
+++ b/components/Testimonial/TestimonialSlider.tsx
@@ -1,6 +1,5 @@
 import { FC, useState } from 'react'
 import { Testimonials, isTestimonialAllowed } from '@sirclo/nexus'
-// import Carousel from '@brainhubeu/react-carousel'
 import Slider from 'react-slick'
 import Placeholder from 'components/Placeholder'
 

--- a/package.json
+++ b/package.json
@@ -27,8 +27,10 @@
     "react-icons": "^4.1.0",
     "react-lazy-load-image-component": "^1.5.0",
     "react-share": "^4.4.0",
+    "react-slick": "^0.29.0",
     "react-toastify": "^5.5.0",
-    "sass": "1.39.0"
+    "sass": "1.39.0",
+    "slick-carousel": "^1.8.1"
   },
   "devDependencies": {
     "@babel/preset-react": "^7.10.1",
@@ -36,6 +38,7 @@
     "@types/next": "^9.0.0",
     "@types/node": "^12.12.45",
     "@types/react": "16.14.24",
+    "@types/react-slick": "^0.23.7",
     "npm-link-shared": "^0.5.6",
     "typescript": "^4.1.6",
     "url-loader": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "build:staging": "env-cmd -f .env.staging next build"
   },
   "dependencies": {
-    "@brainhubeu/react-carousel": "^1.19.26",
     "@elgorditosalsero/react-gtm-hook": "^2.4.0",
     "@sirclo/nexus": "2.14.4",
     "bootstrap": "^4.5.0",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,6 +1,8 @@
-import "@brainhubeu/react-carousel/lib/style.css";
+// import "@brainhubeu/react-carousel/lib/style.css";
 import "react-toastify/dist/ReactToastify.css";
 import "public/scss/main.scss";
+import "slick-carousel/slick/slick.css";
+import "slick-carousel/slick/slick-theme.css";
 
 import { useState, useEffect } from "react";
 import {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,4 +1,3 @@
-// import "@brainhubeu/react-carousel/lib/style.css";
 import "react-toastify/dist/ReactToastify.css";
 import "public/scss/main.scss";
 import "slick-carousel/slick/slick.css";

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,7 +1,8 @@
-import "react-toastify/dist/ReactToastify.css";
-import "public/scss/main.scss";
+
 import "slick-carousel/slick/slick.css";
 import "slick-carousel/slick/slick-theme.css";
+import "react-toastify/dist/ReactToastify.css";
+import "public/scss/main.scss";
 
 import { useState, useEffect } from "react";
 import {

--- a/public/scss/components/Banner.module.scss
+++ b/public/scss/components/Banner.module.scss
@@ -1,6 +1,6 @@
 @import '../utils/_variables.scss';
 
-.banner-carousel{
+.bannerCarousel {
   a
   {
       width: 100%;
@@ -37,3 +37,12 @@
       }
   }
 }
+
+@media (max-width: #{$breakpoint_min_sm}) 
+{
+  .bannerCarousel
+  {
+    margin-top: 70px;
+  }
+}
+

--- a/public/scss/components/Banner.module.scss
+++ b/public/scss/components/Banner.module.scss
@@ -7,19 +7,22 @@
 
 .bannerCarousel
 {
-  &_header {
+  &_header
+  {
     flex: 0 0 100%;
     text-align: center;
     cursor: pointer;
   }
 
-  &_link {
+  &_link
+  {
     display: block;
     width: 100%;
     height: auto;
   }
 
-  &_image {
+  &_image
+  {
     width: 100%;
     height: auto;
     object-fit: cover;
@@ -37,13 +40,17 @@
     @include fixedHeight(100%);
   }
 
-  .slick-dots {
+  .slick-dots
+  {
       bottom: 25px;
   }
 
-  .slick-active {
-      button {
-          &::before {
+  .slick-active
+  {
+      button
+      {
+          &::before
+          {
               color: $color-white;
           }
       }

--- a/public/scss/components/Banner.module.scss
+++ b/public/scss/components/Banner.module.scss
@@ -1,41 +1,39 @@
 @import '../utils/_variables.scss';
 
-.container
-{
-  position: relative
-}
-
-.bannerCarousel
-{
-  &_header {
-    flex: 0 0 100%;
-    text-align: center;
-    cursor: pointer;
-  }
-
-  &_link {
-    display: block;
-    width: 100%;
-    height: auto;
-  }
-
-  &_image {
-    width: 100%;
-    height: auto;
-    object-fit: cover;
-  }
-
-  &_placeholder
+.banner-carousel{
+  a
   {
-    height: 100vh;
+      width: 100%;
   }
-}
 
-
-@media (max-width: #{$breakpoint_min_sm}) 
-{
-  .container
+  &__header
   {
-    margin-top: 70px;
+      flex: 0 0 100%;
+      text-align: center;
+      cursor: pointer;
+  }
+
+  &__image
+  {
+      width: 100%;
+  }
+
+  .slick-slider,
+  .slick-list
+  {
+    @include fixedWidth(100%);
+    @include fixedHeight(100%);
+  }
+
+  .slick-dots {
+      bottom: 25px;
+  }
+
+  .slick-active {
+      button {
+          &::before {
+              color: $color-white;
+          }
+      }
   }
 }

--- a/public/scss/components/Banner.module.scss
+++ b/public/scss/components/Banner.module.scss
@@ -1,23 +1,35 @@
 @import '../utils/_variables.scss';
 
-.bannerCarousel {
-  a
-  {
-      width: 100%;
+.container
+{
+  position: relative
+}
+
+.bannerCarousel
+{
+  &_header {
+    flex: 0 0 100%;
+    text-align: center;
+    cursor: pointer;
   }
 
-  &__header
-  {
-      flex: 0 0 100%;
-      text-align: center;
-      cursor: pointer;
+  &_link {
+    display: block;
+    width: 100%;
+    height: auto;
   }
 
-  &__image
-  {
-      width: 100%;
+  &_image {
+    width: 100%;
+    height: auto;
+    object-fit: cover;
   }
 
+  &_placeholder
+  {
+    height: 100vh;
+  }
+  
   .slick-slider,
   .slick-list
   {
@@ -36,13 +48,14 @@
           }
       }
   }
+
 }
+
 
 @media (max-width: #{$breakpoint_min_sm}) 
 {
-  .bannerCarousel
+  .container
   {
     margin-top: 70px;
   }
 }
-

--- a/public/scss/components/Footer.module.scss
+++ b/public/scss/components/Footer.module.scss
@@ -4,7 +4,7 @@
 {
   display: block;
   position: relative;
-  margin: 58px 0 0 300px;
+  margin: 0 0 0 300px;
   padding: 0 calc(42px - 15px);
   background-color: $color_black;
   color: $color_white;

--- a/public/scss/components/Header.module.scss
+++ b/public/scss/components/Header.module.scss
@@ -20,13 +20,24 @@
     overflow-x: hidden;
     overflow-y: auto;
 
-    & ~ main,
+    & ~ main
+    {
+        @include transition();
+        @include fixedWidth(calc(100vw - 280px));
+        margin-left: 280px;
+        min-height: calc(100vh - 310px); // ditambah sama margin footer
+    }
     & ~ footer
     {
         @include transition();
-        @include fixedWidth(calc(100vw - 300px));
+        @include fixedWidth(calc(100vw - 280px));
+        min-height: 260px;
         margin-left: 280px;
+        z-index: 3;
+        bottom: 0;
+        position: relative;
     }
+    
 }
 
 .item

--- a/public/scss/components/Header.module.scss
+++ b/public/scss/components/Header.module.scss
@@ -25,13 +25,14 @@
         @include transition();
         @include fixedWidth(calc(100vw - 280px));
         margin-left: 280px;
-        min-height: calc(100vh - 310px); // ditambah sama margin footer
+        min-height: calc(100vh - 280px);
+        padding-bottom: 58px; 
     }
     & ~ footer
     {
         @include transition();
         @include fixedWidth(calc(100vw - 280px));
-        min-height: 260px;
+        min-height: 280px;
         margin-left: 280px;
         z-index: 3;
         bottom: 0;


### PR DESCRIPTION
Tampilan slideshownya, terdapat space di bagian atas dan bawah
Tampilan IG feed dan slideshow blur imagenya mobile version
**Chrome mobile view**

> Banner
<img width="1107" alt="Screen Shot 2022-09-08 at 09 21 24" src="https://user-images.githubusercontent.com/28738321/189019594-9900028e-40b1-48e5-beae-51ac0616cdad.png">

> Instagram
<img width="1107" alt="Screen Shot 2022-09-08 at 09 21 42" src="https://user-images.githubusercontent.com/28738321/189019617-1d813877-cb28-4c6f-8c2c-06398a63c669.png">

Desktop view
> Banner
<img width="1680" alt="Screen Shot 2022-09-08 at 09 22 44" src="https://user-images.githubusercontent.com/28738321/189019836-496cb9a9-40ac-4e75-bb04-fd4d6027bbed.png">

>Footer & Intagram
<img width="1680" alt="Screen Shot 2022-09-08 at 09 22 57" src="https://user-images.githubusercontent.com/28738321/189019953-ec4e445e-ebe7-4353-bda6-1b75b28e5fd5.png">

Mobile Device view
>Banner
<img width="490" alt="Screen Shot 2022-09-08 at 09 23 29" src="https://user-images.githubusercontent.com/28738321/189020002-fd29bc8a-2927-48c4-a8de-fc91b120d444.png">

> Instagram
<img width="487" alt="Screen Shot 2022-09-08 at 09 23 55" src="https://user-images.githubusercontent.com/28738321/189020018-24718fb5-6318-465c-8ce9-77c5530f66d3.png">

> Footer
<img width="487" alt="Screen Shot 2022-09-08 at 09 24 21" src="https://user-images.githubusercontent.com/28738321/189020034-ae7969ef-ecc3-4120-8610-4495a3967910.png">

