### PR TITLE
fix: fix horizontal scroll on windowed page

### DIFF
--- a/public/scss/components/Header.module.scss
+++ b/public/scss/components/Header.module.scss
@@ -23,17 +23,17 @@
     & ~ main
     {
         @include transition();
-        @include fixedWidth(calc(100vw - 280px));
-        margin-left: 280px;
-        min-height: calc(100vh - 280px);
+        width: auto;
+        margin-left: 300px;
+        min-height: calc(100vh - 300px);
         padding-bottom: 58px; 
     }
     & ~ footer
     {
         @include transition();
-        @include fixedWidth(calc(100vw - 280px));
-        min-height: 280px;
-        margin-left: 280px;
+        width: auto;
+        min-height: 300px;
+        margin-left: 300px;
         z-index: 3;
         bottom: 0;
         position: relative;
@@ -245,7 +245,7 @@
         & ~ main,
         & ~ footer
         {
-            @include fixedWidth(100vw);
+            width: auto;
             margin-left: 0;
         }
 


### PR DESCRIPTION
## Task
https://phabricator.sirclo.com/T39139
Fix horizontal scroll showing on windowed page

## Root Cause
- If the page has a vertical scroll, it takes some space of the total 100vw width, creating an overflow horizontally
- The left margin of the main layout section isn't the same as the sidebar's width

## Solution
- Change the width from a fixed width to auto width
- Change the left margin value from 280px to 300px

## Screenshot
#### Desktop
![image](https://user-images.githubusercontent.com/68508069/196073400-e3e00a03-dba0-4ca3-90e8-38f60b09ede1.png)
![image](https://user-images.githubusercontent.com/68508069/196073438-9a43be07-dfcc-4dcc-989b-dc3af157e866.png)
#### Mobile
![image](https://user-images.githubusercontent.com/68508069/196076848-8be296ed-5159-4e6c-80b5-3f83e56fc91f.png)
![image](https://user-images.githubusercontent.com/68508069/196076905-ed92c079-c4a4-4fba-8d9f-646eb8e109a1.png)
![image](https://user-images.githubusercontent.com/68508069/196079706-ebe16e15-8436-4c30-8ad6-2ec906fe6192.png)
![image](https://user-images.githubusercontent.com/68508069/196077971-ca6059bc-6e63-483e-b68a-5d2c76b8cea7.png)

## Recording
https://user-images.githubusercontent.com/68508069/196075286-b1568db8-8c9c-47f4-a1b6-49721b277559.mp4