### PR TITLE
fix: handle product categories long texts

### DIFF
--- a/public/scss/components/ProductCategory.module.scss
+++ b/public/scss/components/ProductCategory.module.scss
@@ -60,14 +60,15 @@
   &_link
   {
     @include flex(row-reverse, center, flex-end);
-    width: fit-content;
   }
   
   &_name
   {
     @include typography_builder(500, 20, 24);
+    @include truncate();
     width: 100%;
     color: $color_text;
+    position: relative;
 
     &:hover
     {
@@ -76,9 +77,11 @@
     
     span
     {
-      display: inline-block;
       @include typographyBuilder(400, 12, 16);
-      margin-left: 8px;
+      display: inline-block;
+      position: absolute;
+      right: 0;
+      top: 6px;
     }
   }
 
@@ -159,7 +162,7 @@
   &_itemCategories
   {
     list-style: none;
-    width: calc(30% - 24px);
+    width: calc(30% - 8px);
     height: 24px;
     margin-bottom: 20px;
 
@@ -234,6 +237,10 @@
   &_valueContainer
   {
     @include flex(row, center, space-between);
+    & > div
+    {
+      width: 100%;
+    }
   }
   
   &_selectedCategory

--- a/public/scss/components/ProductCategory.module.scss
+++ b/public/scss/components/ProductCategory.module.scss
@@ -84,10 +84,8 @@
     span
     {
       @include typographyBuilder(400, 12, 16);
+      @include position(absolute, 6px, 0, auto, auto);
       display: inline-block;
-      position: absolute;
-      right: 0;
-      top: 6px;
     }
   }
 

--- a/public/scss/components/ProductCategory.module.scss
+++ b/public/scss/components/ProductCategory.module.scss
@@ -60,6 +60,12 @@
   &_link
   {
     @include flex(row-reverse, center, flex-end);
+    width: calc(100% + 24px);
+
+    @media screen and (max-width: #{$breakpoint_max_md})
+    {
+      width: calc(100%);
+    }
   }
   
   &_name
@@ -162,7 +168,7 @@
   &_itemCategories
   {
     list-style: none;
-    width: calc(30% - 8px);
+    width: calc(30% - 32px);
     height: 24px;
     margin-bottom: 20px;
 
@@ -237,9 +243,13 @@
   &_valueContainer
   {
     @include flex(row, center, space-between);
-    & > div
+
+    @media (max-width: #{$breakpoint_min_sm})
     {
-      width: 100%;
+      & > div
+      {
+        width: 100%;
+      }
     }
   }
   


### PR DESCRIPTION
**Before**

Desktop:
![Screenshot from 2022-10-27 11-03-06](https://user-images.githubusercontent.com/40454642/198188675-0465ec28-1df3-423d-a3c6-3a8b74674ee2.png)

Mobile:
![Screenshot from 2022-10-27 11-03-12](https://user-images.githubusercontent.com/40454642/198188700-3a8f62f8-4d05-4456-ad60-382df8fd829b.png)

**After**

Desktop:
![Screenshot from 2022-10-27 11-24-11](https://user-images.githubusercontent.com/40454642/198191146-94ef0ae1-973c-437c-932b-e64938bf5118.png)
Dengan gambar:
![Screenshot from 2022-10-27 11-24-14](https://user-images.githubusercontent.com/40454642/198191093-12b58faf-fbcb-4ec5-9015-cdd80080a991.png)


Mobile:
![Screenshot from 2022-10-27 11-24-21](https://user-images.githubusercontent.com/40454642/198191187-8e37fdc4-37e1-49bd-a624-6ddb8837ce60.png)