### PR TITLE
fix: checkout button shipping 0

### DIFF
--- a/components/OrderSummaryBox/index.tsx
+++ b/components/OrderSummaryBox/index.tsx
@@ -8,9 +8,6 @@ import {
   PrivateComponent
 } from '@sirclo/nexus'
 
-/* library component */
-import useWindowSize from 'lib/useWindowSize'
-
 /* component */
 import Placeholder from 'components/Placeholder'
 import Popup from 'components/Popup/Popup'
@@ -167,7 +164,6 @@ const OrderSummaryBox: FC<iProps> = ({
   withOrderSummary = true
 }) => {
 
-  const size = useWindowSize()
   const [showModalErrorAddToCart, setShowModalErrorAddToCart] = useState<boolean>(false)
   const toogleErrorAddToCart = () => setShowModalErrorAddToCart(!showModalErrorAddToCart)
 

--- a/components/OrderSummaryBox/index.tsx
+++ b/components/OrderSummaryBox/index.tsx
@@ -254,9 +254,6 @@ const OrderSummaryBox: FC<iProps> = ({
             isAccordion
             classes={{
               ...classesOrderSummary,
-              footerClassName: page !== "cart" && size.width > 767
-                ? "d-none"
-                : classesOrderSummary.footerClassName,
               containerClassName: page === "cart" ? styles.containerRelative : styles.container
             }}
             currency="IDR"

--- a/pages/[lng]/place_order/index.tsx
+++ b/pages/[lng]/place_order/index.tsx
@@ -2,7 +2,6 @@
 import { FC } from 'react'
 import { GetServerSideProps, InferGetServerSidePropsType } from 'next'
 import { toast } from 'react-toastify'
-import { useRouter } from 'next/router'
 import {
   PlaceOrderFormv2,
   useI18n,
@@ -170,21 +169,12 @@ const PlaceOrderPage: FC<any> = ({
 
   const i18n: any = useI18n()
   const size = useWindowSize()
-  const router = useRouter()
   const linksBreadcrumb = [`${i18n.t("header.home")}`, i18n.t("placeOrder.checkOrder")]
   const layoutProps = {
     lngDict, i18n, lng, brand,
     withFooter: false,
     withHeader: false,
     SEO: { title: `${i18n.t("orderSummary.placeOrder")}` }
-  }
-
-  let withButtonProps = {}
-  if (size.width > 767) withButtonProps = {
-    withButton: () => router.push({
-      pathname: "/[lng]/shipping_method",
-      query: router.query
-    })
   }
 
   return (
@@ -238,7 +228,6 @@ const PlaceOrderPage: FC<any> = ({
             }
             mapCenterIcon={<Icon.mapCenterIcon />}
             mapButtonCloseIcon={<Icon.RiCloseFill />}
-            {...withButtonProps}
           />
           <div className={styles.orderSummaryBoxContainer}>
             <OrderSummaryBox

--- a/pages/[lng]/shipping_method/index.tsx
+++ b/pages/[lng]/shipping_method/index.tsx
@@ -115,14 +115,6 @@ const ShippingMethodPage: FC<any> = ({
     SEO: { title: `${i18n.t("shipping.title")}` }
   }
 
-  let withButtonProps = {}
-  if (size?.width > 767) withButtonProps = {
-    withButton: () => router.push({
-      pathname: "/[lng]/payment_method",
-      query: router.query
-    })
-  }
-
   return (
     <PrivateRouteWrapper>
       <Layout {...layoutProps} >
@@ -184,7 +176,6 @@ const ShippingMethodPage: FC<any> = ({
                   listMany={9}
                 />
               }
-              {...withButtonProps}
             />
           </div>
           <div className={styles.orderSummaryBoxContainer}>

--- a/public/scss/pages/ShippingMethod.module.scss
+++ b/public/scss/pages/ShippingMethod.module.scss
@@ -67,7 +67,7 @@
     }
   }
 
-  &[class*=disabled]
+  &[class*="disabled"]
   {
     opacity: .5;
     pointer-events: none;

--- a/public/scss/pages/ShippingMethod.module.scss
+++ b/public/scss/pages/ShippingMethod.module.scss
@@ -58,13 +58,19 @@
       {
         content: "";
         @include fixedSize(12px);
-        @include position(absolute, 50%, auto, auto, 15%);
+        @include position(absolute, 50%, auto, auto, 17%);
         transform: translateY(-50%);
         display: block;
         border-radius: 100%;
         background: $color_black;
       }
     }
+  }
+
+  &[class*=disabled]
+  {
+    opacity: .5;
+    pointer-events: none;
   }
 }
 
@@ -89,7 +95,7 @@
     {
       content: "";
       @include fixedSize(12px);
-      @include position(absolute, 50%, auto, auto, 15%);
+      @include position(absolute, 50%, auto, auto, 17%);
       transform: translateY(-50%);
       display: block;
       border-radius: 100%;
@@ -118,7 +124,7 @@
     {
       content: "";
       @include fixedSize(12px);
-      @include position(absolute, 50%, auto, auto, 15%);
+      @include position(absolute, 50%, auto, auto, 17%);
       transform: translateY(-50%);
       display: block;
       border-radius: 100%;
@@ -204,7 +210,8 @@
 
 .warningPinPoint
 {
-  @include position(absolute, 1px, 16px);
+  @include position(absolute, 6px, 16px);
+  @include fontSize(12);
   color: $color_text_secondary;
 }
 


### PR DESCRIPTION
### Problem:
- Tidak bisa checkout ketika custom shipping 0, button checkout disabled
![Screen Shot 2022-10-27 at 20 52 20](https://user-images.githubusercontent.com/8541505/198328435-c8352357-8f9c-41dc-bb3f-483132b0336b.png)

### Root Cause:
- Menggunakan custom button yang ditaruh di bagian kiri, bukan dari component order summary box

### Solusi:
- Kembali menggunakan button di component order summary box.
- Di page place order, custom shipping button ditaruh di kanan, dan di shipping method juga dipindah ke kanan supaya seragam
- Disabled shipping yang tidak bisa digunakan supaya ga bisa diklik
![Screen Shot 2022-10-27 at 20 54 53](https://user-images.githubusercontent.com/8541505/198329445-2879dd4f-3e34-4c0b-8e98-145427242407.png)

![Screen Shot 2022-10-27 at 20 53 33](https://user-images.githubusercontent.com/8541505/198329438-b994346f-134c-4966-a814-5d038c2163ee.png)


### Others:
- Benerin checkbox supaya tepat berada di tengah buletan itemnya
- Kecilin sedikit tulisan Tentukan titik alamat supaya lebih rapi
