### PR TITLE
fix: enable email newsletter in footer

### DIFF
--- a/public/scss/components/FooterWidget.module.scss
+++ b/public/scss/components/FooterWidget.module.scss
@@ -80,11 +80,6 @@
     {
         @include transition();
         position: relative;
-        
-        @media screen and (max-width: #{$breakpoint_max_md})
-        {
-            pointer-events: none;
-        }
     }
     
     &_toggle


### PR DESCRIPTION
**Problem**
 
- Can't click the email newsletter in footer (disabled)

**Solution**

- Remove the `pointer-events` in mobile view

**Proof of Work**

[Video](https://drive.google.com/file/d/1fqKwksd3oL2uZo-n4_LmfQ_O2nYyfBaj/view?usp=share_link)