### PR TITLE
fix: widget collapsible not working

### DIFF
--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -110,16 +110,15 @@ const Footer: FC<any> = () => {
           }
           <div className="col-12 col-md-3">
             <div className={styles.footerItem}>
-              <FooterWidget title={i18n.t("newsletter.title")} collapsible={false}>
-                <NewsletterForm
-                  classes={classesNewsletter}
-                  onComplete={() => toast.success(i18n.t("newsletter.submitSuccess"))}
-                  onError={() => toast.error(i18n.t("newsletter.submitError"))}
-                  buttonComponent={
-                    <FaArrowRight />
-                  }
-                />
-              </FooterWidget>
+              <h3 className={styles.footerNewsletter_title}>{i18n.t("newsletter.title")}</h3>
+              <NewsletterForm
+                classes={classesNewsletter}
+                onComplete={() => toast.success(i18n.t("newsletter.submitSuccess"))}
+                onError={() => toast.error(i18n.t("newsletter.submitError"))}
+                buttonComponent={
+                  <FaArrowRight />
+                }
+              />
             </div>
           </div>
         </div>

--- a/public/scss/components/Footer.module.scss
+++ b/public/scss/components/Footer.module.scss
@@ -43,6 +43,15 @@
     }
   }
 
+  &_newsletterTitle
+  {
+    @include flex(row, center, flex-start);
+    @include typographyBuilder(700, 16, 24);
+    position: relative;
+    margin-bottom: 16px;
+    color: $color_white;
+  }
+
   &Item
   {
     @include typographyBuilder(400, 12, 16);
@@ -152,6 +161,15 @@
     border: solid 1px $color_text_secondary;
     border-radius: 2px;
 
+    &_title
+    {
+      @include flex(row, center, flex-start);
+      @include typographyBuilder(700, 16, 24);
+      position: relative;
+      margin-bottom: 16px;
+      color: $color_white;
+    }
+
     &_label
     {
       display: none;
@@ -202,6 +220,18 @@
 {
   .footer
   {
+    &Newsletter
+    {  
+      &_title
+      {
+        @include flex(row, center, flex-start);
+        @include typographyBuilder(700, 16, 24);
+        position: relative;
+        margin-bottom: 16px;
+        color: $color_white;
+      }
+    }
+
     &Item
     {
       padding: 0 3px;

--- a/public/scss/components/FooterWidget.module.scss
+++ b/public/scss/components/FooterWidget.module.scss
@@ -80,6 +80,11 @@
     {
         @include transition();
         position: relative;
+
+        @media screen and (max-width: #{$breakpoint_max_md})
+        {
+            pointer-events: none;
+        }
     }
     
     &_toggle


### PR DESCRIPTION
### Problem

- widget tidak bisa di klik + nya (dibuka tutup)
- tersenggol dari fixing email newsletter `pointers-event: none` kemarin

### Solution

- ubah email newsletternya tidak dijadikan bagian dari komponen footer widget (contoh: dari template merlin)

Note:
- email newsletter tetap dapat di klik (dan berlangganan)
- widget bisa diklik buka tutup

### Proof of Work

[Video 1](https://drive.google.com/file/d/1zb79ekz1UfM_pKhtnxQT3RhNO3mWVY2d/view?usp=sharing)

[Video 2](https://drive.google.com/file/d/1BiU4T0yRw_VQi0Y9B7qbKHvAfgzzwrZO/view?usp=sharing)