### PR TITLE
fix: adjust style for footer widget 1

### DIFF
--- a/public/scss/components/FooterWidget.module.scss
+++ b/public/scss/components/FooterWidget.module.scss
@@ -54,6 +54,18 @@
             border-bottom: none !important;
             display: none;
         }
+
+        @media screen and (max-width: #{$breakpoint_max_md})
+        {
+            [class*="footerItem_content"]
+            {
+                h1, h2, h3, h4, h5, h6
+                {
+                    min-height: fit-content !important;
+                    margin-top: 0 !important;
+                }
+            } 
+        }
     }
 
     &_header


### PR DESCRIPTION
### Problem

- Widget Footer 1 terpotong jika menggunakan teks (h1, h2, h3, h4, h5, h6) karena stylingnya keikut dengan yang collapsible
- Widget Footer 1 expectednya tidak dijadikan collapsible
- Yang terpotong hanyalah di mobile

<img width="960" alt="image" src="https://user-images.githubusercontent.com/45808774/202424575-3f3a905c-ddb2-4ffd-84ee-31a4ec6c9aff.png">

<img width="180" alt="image" src="https://user-images.githubusercontent.com/45808774/202424945-85ada6a3-c185-4fcb-b9ca-e713d2376b9b.png">

### Proof of Work

Mobile

<img width="188" alt="image" src="https://user-images.githubusercontent.com/45808774/202424397-74b5dab6-e9d5-43df-97ca-81df03e9e187.png">

Desktop

<img width="960" alt="image" src="https://user-images.githubusercontent.com/45808774/202424450-b63d2879-1038-416a-b5c0-ddea147b36e6.png">
