### PR TITLE
fix(coupon): add popup max height and payment invalid coupon error wording

### DIFF
--- a/locales/en/payment.ts
+++ b/locales/en/payment.ts
@@ -6,6 +6,7 @@ const locale = {
     "choosePayment": "Select Payment",
     "confirm": "Send Proof of Payment",
     "discountBundle": "Discount Bundle",
+    "errorPaymentMethodByCoupon": "Sorry, the coupon is not valid on the selected payment method",
     "fee": "Fee",
     "generateLinkFailed": "Failed to use this payment method",
     "isEmpty": "No Available Payment Method",

--- a/locales/id/payment.ts
+++ b/locales/id/payment.ts
@@ -6,6 +6,7 @@ const locale = {
     "choosePayment": "Pilih Pembayaran",
     "confirm": "Kirim Bukti Pembayaran",
     "discountBundle": "Paket Diskon",
+    "errorPaymentMethodByCoupon": "Maaf, kupon tidak berlaku pada metode pembayaran yang di pilih",
     "fee": "Biaya",
     "generateLinkFailed": "Gagal menggunakan metode pembayaran",
     "isEmpty": "Tidak Ada Metode Pembayaran yang Tersedia",

--- a/public/scss/components/PopUpVoucherCoupon.module.scss
+++ b/public/scss/components/PopUpVoucherCoupon.module.scss
@@ -576,7 +576,7 @@
 
   max-width: 100vw;
   max-height: 80vh;
-  overflow-y: auto;
+  width: 100%;
 
   @media screen and (min-width: #{$breakpoint_min_sm})
   {
@@ -625,6 +625,7 @@
 .voucherDetailPopUpDescContainer
 {
   padding: 16px;
+  overflow-y: auto;
 }
 
 .voucherDetailPopUpTermsTitle

--- a/public/scss/components/PopUpVoucherCoupon.module.scss
+++ b/public/scss/components/PopUpVoucherCoupon.module.scss
@@ -575,13 +575,13 @@
   border-radius: 2px;
 
   max-width: 100vw;
-  max-height: 100vh;
+  max-height: 80vh;
+  overflow-y: auto;
 
   @media screen and (min-width: #{$breakpoint_min_sm})
   {
     position: relative;
     max-width: 417px;
-    max-height: max-content;
   }
 }
 


### PR DESCRIPTION
Yang di make sure:

1. Untuk bagain kupon yang invalid, tombol "Lihat Detail" masih tetap aktif, yang di disabled hanya bagian kuponnya dan tombol "Gunakan Kupon" di PopUpDetail juga stylingnya dibuat disabled.

Coupon valid button aktif:
![Screenshot from 2022-11-18 14-29-57](https://user-images.githubusercontent.com/40454642/202653463-fced4944-ebd9-4292-8fbd-b5f612157df2.png)
![Screenshot from 2022-11-18 15-13-05](https://user-images.githubusercontent.com/40454642/202653476-c6d1a189-9cd7-439e-96d2-f9ed4a5cb501.png)

Coupon invalid button disabled:
![Screenshot from 2022-11-18 14-30-02](https://user-images.githubusercontent.com/40454642/202653547-f5ced25c-2a0a-44cd-aa3f-c590f3956edf.png)
![Screenshot from 2022-11-18 15-13-10](https://user-images.githubusercontent.com/40454642/202653560-8f2e1ec1-fe2c-4f60-a19f-d436080cb67f.png)

2. Tinggi PopUpDetail yang berisi syarat dan ketentuan itu diset ketinggian maksimalnya 80vh.
![Screenshot from 2022-11-18 14-32-08](https://user-images.githubusercontent.com/40454642/202653744-ffd4d83a-7c19-44b2-827c-6df35b6ed635.png)
![Screenshot from 2022-11-18 15-14-52](https://user-images.githubusercontent.com/40454642/202653756-d7d6cf3f-3ffb-478d-8c6e-dc23d28e3806.png)

3. Wording invalid coupon di payment_method
![Screenshot from 2022-11-18 15-04-42](https://user-images.githubusercontent.com/40454642/202653798-a6500019-281c-404d-b6d5-e0b427538e8f.png)
