### PR TITLE
fix: coupon code text overflow

### DIFF
--- a/public/scss/components/PopUpVoucherCoupon.module.scss
+++ b/public/scss/components/PopUpVoucherCoupon.module.scss
@@ -663,6 +663,7 @@
   @include fixedWidth(100%);
   padding: 16px;
   border-top: 1px dashed $color_placeholder;
+  word-wrap: anywhere;
 }
 
 .voucherDetailPopUpCodeTitle
@@ -683,7 +684,6 @@
 .voucherDetailPopUpCodeCopyTitle
 {
   @include typographyBuilder(500, 12, 16);
-  @include textOverflow();
   margin: 0;
 }
 

--- a/public/scss/components/PopUpVoucherCoupon.module.scss
+++ b/public/scss/components/PopUpVoucherCoupon.module.scss
@@ -607,6 +607,8 @@
   border: none;
   background-color: transparent;
   color: $color_black;
+  min-height: 24px;
+  min-width: 24px;
 
   &:hover,
   &:active,
@@ -681,6 +683,7 @@
 .voucherDetailPopUpCodeCopyTitle
 {
   @include typographyBuilder(500, 12, 16);
+  @include textOverflow();
   margin: 0;
 }
 

--- a/public/scss/utils/_mixins.scss
+++ b/public/scss/utils/_mixins.scss
@@ -540,3 +540,11 @@
       background: $color_foreground;
     }
 }
+
+@mixin textOverflow()
+{
+    white-space: nowrap;
+    word-break: keep-all;
+    text-overflow: ellipsis;
+    overflow: hidden;
+}

--- a/public/scss/utils/_mixins.scss
+++ b/public/scss/utils/_mixins.scss
@@ -540,11 +540,3 @@
       background: $color_foreground;
     }
 }
-
-@mixin textOverflow()
-{
-    white-space: nowrap;
-    word-break: keep-all;
-    text-overflow: ellipsis;
-    overflow: hidden;
-}


### PR DESCRIPTION
Before:
![Screenshot from 2022-11-23 11-59-53](https://user-images.githubusercontent.com/40454642/203472291-9c6dcb42-c6b1-4405-9fe0-fee649495acf.png)
![Screenshot from 2022-11-23 12-00-03](https://user-images.githubusercontent.com/40454642/203472295-4b6bd0df-7b01-47d1-b720-883047c87a81.png)

After:
![Screenshot from 2022-11-23 13-46-04](https://user-images.githubusercontent.com/40454642/203486710-8572df46-9d1a-4334-acb9-22c1a54d1031.png)
![Screenshot from 2022-11-23 13-46-07](https://user-images.githubusercontent.com/40454642/203486723-6735db5f-6aaf-47ec-8915-fb2642a9c7ca.png)
