### PR TITLE
fix(coupon): add coupon popup title word wrap

### DIFF
--- a/public/scss/components/PopUpVoucherCoupon.module.scss
+++ b/public/scss/components/PopUpVoucherCoupon.module.scss
@@ -143,6 +143,8 @@
   background-color: $color_white;
   border-radius: 2px;
   overflow-y: auto;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
 
   @media screen and (min-width: #{$breakpoint_min_md})
   {
@@ -153,6 +155,11 @@
   {
     padding: 24px 135px;
   }
+}
+
+.voucherContainer::-webkit-scrollbar
+{
+    display: none;
 }
 
 .voucherTitleInput
@@ -591,6 +598,7 @@
   @include fixedWidth(100%);
   padding: 12px 16px;
   border-bottom: 1px solid $color_placeholder;
+  word-wrap: anywhere;
 }
 
 .voucherDetailPopUpHeaderTitle


### PR DESCRIPTION
Before:
![Screenshot from 2022-11-24 13-48-23](https://user-images.githubusercontent.com/40454642/203713460-25e345c3-4f37-42a0-be94-273b8a0cff07.png)
![Screenshot from 2022-11-24 13-48-21](https://user-images.githubusercontent.com/40454642/203713472-c4e6fff5-4c07-4370-ae04-d74160fe8280.png)

After:
![Screenshot from 2022-11-24 13-48-27](https://user-images.githubusercontent.com/40454642/203713488-3c7998b5-560f-4318-a19e-5e21a8b941dd.png)
![Screenshot from 2022-11-24 13-48-25](https://user-images.githubusercontent.com/40454642/203713497-f84d1b6b-6589-4663-b96d-11c5f232cc46.png)

Hide double scrollbar on google chrome:
[Screencast from 24-11-22 09:38:17.webm](https://user-images.githubusercontent.com/40454642/203713553-0822b294-643e-4f66-90db-2af7863ed4da.webm)
