### PR TITLE
feat: product highlight list page

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@elgorditosalsero/react-gtm-hook": "^2.4.0",
-    "@sirclo/nexus": "2.16.9",
+    "@sirclo/nexus": "2.17.4",
     "bootstrap": "^4.5.0",
     "cookie": "^0.4.1",
     "env-cmd": "^10.1.0",

--- a/pages/[lng]/products/[slug].tsx
+++ b/pages/[lng]/products/[slug].tsx
@@ -62,7 +62,7 @@ const ProductsHighlightPage: FC<any> = ({
     i18n,
     lng,
     brand,
-    SEO: { titleProductSection },
+    SEO: { title: titleProductSection },
     withBack: false,
     titleSeo: titleProductSection
   }

--- a/pages/[lng]/products/[slug].tsx
+++ b/pages/[lng]/products/[slug].tsx
@@ -62,7 +62,7 @@ const ProductsHighlightPage: FC<any> = ({
     i18n,
     lng,
     brand,
-    SEO: { title: titleProductSection },
+    SEO: { titleProductSection },
     withBack: false,
     titleSeo: titleProductSection
   }

--- a/pages/[lng]/products/[slug].tsx
+++ b/pages/[lng]/products/[slug].tsx
@@ -67,35 +67,35 @@ const ProductsHighlightPage: FC<any> = ({
     titleSeo: titleProductSection
   }
   
-  const [currPage, setCurrPage] = useState(0);
+  const [currPage, setCurrPage] = useState(0)
   const [pageInfo, setPageInfo] = useState({
     pageNumber: 0,
     itemPerPage: 12,
     totalItems: 0,
   })
   
-  const totalPage = Math.ceil(pageInfo.totalItems / pageInfo.itemPerPage);
+  const totalPage = Math.ceil(pageInfo.totalItems / pageInfo.itemPerPage)
   
   useEffect(() => {
-    window.addEventListener("scroll", handleScroll);
-    return () => window.removeEventListener("scroll", handleScroll);
-  });
+    window.addEventListener("scroll", handleScroll)
+    return () => window.removeEventListener("scroll", handleScroll)
+  })
 
   const handleScroll = () => {
     const lastItem = document.querySelector(
       ".products_container:last-of-type"
-    ) as HTMLElement;
+    ) as HTMLElement
 
     if (lastItem) {
-      const lastItemOffset = lastItem.offsetTop + lastItem.clientHeight;
-      const pageOffset = window.pageYOffset + window.innerHeight;
-      if (pageOffset > lastItemOffset && currPage < totalPage - 1) setCurrPage(currPage + 1);
+      const lastItemOffset = lastItem.offsetTop + lastItem.clientHeight
+      const pageOffset = window.pageYOffset + window.innerHeight
+      if (pageOffset > lastItemOffset && currPage < totalPage - 1) setCurrPage(currPage + 1)
     }
-  };
+  }
 
   const scrollToTop = () => {
-    document.body.scrollTop = 0; // For Safari
-    document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE and Opera
+    document.body.scrollTop = 0 // For Safari
+    document.documentElement.scrollTop = 0 // For Chrome, Firefox, IE and Opera
   }
 
   type TProductsProps = {

--- a/pages/[lng]/products/[slug].tsx
+++ b/pages/[lng]/products/[slug].tsx
@@ -146,7 +146,7 @@ const ProductsHighlightPage: FC<any> = ({
 
   return (
     <Layout {...layoutProps}>
-      <section className={styleProducts.productsHighlight_breadcumb}>
+      <section className={styleProducts.productsHighlight_breadcrumb}>
         <Breadcrumb
           title={titleProductSection}
           links={linksBreadcrumb}

--- a/pages/[lng]/products/[slug].tsx
+++ b/pages/[lng]/products/[slug].tsx
@@ -108,7 +108,11 @@ const ProductsHighlightPage: FC<any> = ({
     itemPerPage: number,
     withSeparatedVariant: boolean,
     loadingComponent: any,
+    emptyStateComponent: any,
     isFlipImage: boolean,
+    getTitleProductSection: any,
+    slug: string,
+    isProductSectionHighlight: boolean,
   }
 
   const productsLoadingComponent = [0, 1, 2, 3].map((_, i) => ( <div key={i}> <Placeholder classes={placeholder} withImage withList /> </div> ))
@@ -127,7 +131,17 @@ const ProductsHighlightPage: FC<any> = ({
     itemPerPage: 12,
     withSeparatedVariant: true,
     loadingComponent: productsLoadingComponent,
+    emptyStateComponent: (
+      <EmptyComponent
+        logo={<div className={styles.products_iconEmpty} />}
+        classes={{ emptyContainer: styles.products_emptyContainer }}
+        desc={i18n.t("product.isEmpty")}
+      />
+    ),
     isFlipImage: true,
+    getTitleProductSection: (values: string) => setTitleProductSection(values),
+    slug: slugSection,
+    isProductSectionHighlight: true,
   }
 
   return (
@@ -166,10 +180,7 @@ const ProductsHighlightPage: FC<any> = ({
                   <Products
                     key={i}
                     pageNumber={i}
-                    {...baseProductsProps}
-                    getTitleProductSection={(values: string) => setTitleProductSection(values)}
-                    slug={slugSection}
-                    isProductSectionHighlight
+                    {...baseProductsProps}                    
                   />
                 ))
                 }
@@ -179,13 +190,6 @@ const ProductsHighlightPage: FC<any> = ({
               </div>
             </div>
           </section >
-          {pageInfo.totalItems === 0 &&
-            <EmptyComponent
-              logo={<div className={styles.products_iconEmpty} />}
-              classes={{ emptyContainer: styles.products_emptyContainer }}
-              desc={i18n.t("product.isEmpty")}
-            />
-          }
         </>
       </LazyLoadComponent>
     </Layout>

--- a/pages/[lng]/products/[slug].tsx
+++ b/pages/[lng]/products/[slug].tsx
@@ -1,0 +1,213 @@
+/* library package */
+import {
+  FC,
+  useState,
+  useEffect,
+} from 'react'
+import { LazyLoadComponent } from 'react-lazy-load-image-component'
+import {
+  Products,
+  useAuthToken,
+  useI18n
+} from '@sirclo/nexus'
+
+/* library template */
+import { useBrandCommon } from 'lib/useBrand'
+
+/* component */
+import Layout from 'components/Layout/Layout'
+import Placeholder from 'components/Placeholder'
+import Breadcrumb from 'components/Breadcrumb/Breadcrumb'
+import EmptyComponent from 'components/EmptyComponent/EmptyComponent'
+
+/* styles */
+import styleProducts from 'public/scss/pages/Products.module.scss'
+import styles from 'public/scss/components/ProductsComponent.module.scss'
+
+export const placeholder = {
+  placeholderImage: styles.products_placeholder,
+  placeholderList: styles.products_placeholderList,
+}
+
+export const classesProducts = {
+  productContainerClassName: `products_container ${styles.products_productContainer}`,
+  stickerContainerClassName: styles.products_stickerContainer,
+  outOfStockLabelClassName: `${styles.products_label} ${styles.products_outOfStockLabel}`,
+  saleLabelClassName: `${styles.products_label} ${styles.products_saleLabel}`,
+  comingSoonLabelClassName: `${styles.products_label} ${styles.products_comingSoonLabel}`,
+  openOrderLabelClassName: `${styles.products_label} ${styles.products_openOrderLabel}`,
+  preOrderLabelClassName: `${styles.products_label} ${styles.products_preOrderLabel}`,
+  newLabelClassName: `${styles.products_label} ${styles.products_newLabel}`,
+  productImageContainerClassName: styles.products_productImageContainer,
+  productImageClassName: styles.products_productImage,
+  productLabelContainerClassName: styles.products_productLabelContainer,
+  productTitleClassName: styles.products_productTitle,
+  productPriceClassName: styles.products_productPrice,
+  salePriceClassName: styles.products_salePrice,
+  priceClassName: styles.products_price,
+}
+
+const ProductsHighlightPage: FC<any> = ({
+  lng,
+  lngDict,
+  brand,
+  slugSection
+}) => {
+  const [titleProductSection, setTitleProductSection] = useState<string>("")
+
+  const i18n: any = useI18n()
+  const linksBreadcrumb = [i18n.t("header.home"), titleProductSection]
+  const layoutProps = {
+    lngDict,
+    i18n,
+    lng,
+    brand,
+    SEO: { title: titleProductSection },
+    withBack: false,
+    titleSeo: titleProductSection
+  }
+  
+  const [currPage, setCurrPage] = useState(0);
+  const [pageInfo, setPageInfo] = useState({
+    pageNumber: 0,
+    itemPerPage: 12,
+    totalItems: 0,
+  })
+  
+  const totalPage = Math.ceil(pageInfo.totalItems / pageInfo.itemPerPage);
+  
+  useEffect(() => {
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  });
+
+  const handleScroll = () => {
+    const lastItem = document.querySelector(
+      ".products_container:last-of-type"
+    ) as HTMLElement;
+
+    if (lastItem) {
+      const lastItemOffset = lastItem.offsetTop + lastItem.clientHeight;
+      const pageOffset = window.pageYOffset + window.innerHeight;
+      if (pageOffset > lastItemOffset && currPage < totalPage - 1) setCurrPage(currPage + 1);
+    }
+  };
+
+  const scrollToTop = () => {
+    document.body.scrollTop = 0; // For Safari
+    document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE and Opera
+  }
+
+  type TProductsProps = {
+    classes: any,
+    getPageInfo: any,
+    fullPath: string,
+    pathPrefix: string,
+    lazyLoadedImage: boolean,
+    thumborSetting: any,
+    itemPerPage: number,
+    withSeparatedVariant: boolean,
+    loadingComponent: any,
+    isFlipImage: boolean,
+  }
+
+  const productsLoadingComponent = [0, 1, 2, 3].map((_, i) => ( <div key={i}> <Placeholder classes={placeholder} withImage withList /> </div> ))
+
+  const baseProductsProps: TProductsProps = {
+    classes: classesProducts,
+    getPageInfo: (pageInfo: any) => setPageInfo(pageInfo),
+    fullPath: `product/{id}`,
+    pathPrefix: `product`,
+    lazyLoadedImage: false,
+    thumborSetting: {
+      width: 512,
+      format: "webp",
+      quality: 85,
+    },
+    itemPerPage: 12,
+    withSeparatedVariant: true,
+    loadingComponent: productsLoadingComponent,
+    isFlipImage: true,
+  }
+
+  return (
+    <Layout {...layoutProps}>
+      <section className={styleProducts.productsHighlight_breadcumb}>
+        <Breadcrumb
+          title={titleProductSection}
+          links={linksBreadcrumb}
+          lng={lng}
+        />
+      </section>
+
+      <LazyLoadComponent>
+        <>
+          <section
+            className={`
+              container my-2 
+              ${pageInfo.totalItems !== 0 ? 'pb-4' : ""}
+              ${pageInfo.totalItems !== 0 ? styles.productsComponent_lastSection : ""}      
+            `}
+          >
+            <div className={`${pageInfo.totalItems === 0 && "mb-0"}`}>
+              <div className={styles["productsComponent_showResetContainer--productsHighlight"]}>
+                <p className={styles.productsComponent_show}>
+                  {i18n.t("product.show")}
+                  {" "}{pageInfo.totalItems}{" "}
+                  {i18n.t("product.result")}
+                </p>
+              </div>
+              <div
+                className={`${styles.productsComponent_grid} ${'mt-0 pt-0'}
+                ${pageInfo.totalItems === 0 && "pb-0"}    
+              `}
+              >
+                {Array.from(Array(currPage + 1)).map((_, i) => (
+                  <Products
+                    key={i}
+                    pageNumber={i}
+                    {...baseProductsProps}
+                    getTitleProductSection={(values: string) => setTitleProductSection(values)}
+                    slug={slugSection}
+                    isProductSectionHighlight
+                  />
+                ))
+                }
+                <button onClick={scrollToTop} className={styles.productsComponent_goToTop}>
+                  <div className={styles.productsComponent_arrowUp}></div>
+                </button>
+              </div>
+            </div>
+          </section >
+          {pageInfo.totalItems === 0 &&
+            <EmptyComponent
+              logo={<div className={styles.products_iconEmpty} />}
+              classes={{ emptyContainer: styles.products_emptyContainer }}
+              desc={i18n.t("product.isEmpty")}
+            />
+          }
+        </>
+      </LazyLoadComponent>
+    </Layout>
+  )
+}
+export const getServerSideProps = async ({
+  req,
+  res,
+  params
+}) => {
+  const { slug } = params
+  const [ brand ] = await Promise.all([
+    useBrandCommon(req, params),
+    useAuthToken({req, res, env: process.env})
+  ])
+
+  return {
+    props: {
+      ...brand,
+      slugSection: slug
+    }
+  }
+}
+
+export default ProductsHighlightPage

--- a/pages/[lng]/products/index.tsx
+++ b/pages/[lng]/products/index.tsx
@@ -178,7 +178,7 @@ const ProductsPage: FC<any> = ({
 
   return (
     <Layout {...layoutProps}>
-      <section className={styleProducts.products_breadcumb}>
+      <section className={styleProducts.products_breadcrumb}>
         <Breadcrumb
           title={i18n.t("product.title")}
           links={linksBreadcrumb}

--- a/pages/[lng]/products/index.tsx
+++ b/pages/[lng]/products/index.tsx
@@ -215,7 +215,6 @@ const ProductsPage: FC<any> = ({
                   <button className={`${styles.productsComponent_reset}`} onClick={resetFilter}>
                     {i18n.t("product.reset")}
                   </button>
-
                 </div>
               </>
               <div

--- a/pages/[lng]/products/index.tsx
+++ b/pages/[lng]/products/index.tsx
@@ -92,23 +92,23 @@ const ProductsPage: FC<any> = ({
   const [filterProduct, setFilterProduct] = useState({})
   const categories: string = useQuery('categories')
   
-  const [currPage, setCurrPage] = useState(0);
+  const [currPage, setCurrPage] = useState(0)
   const [pageInfo, setPageInfo] = useState({
     pageNumber: 0,
     itemPerPage: 12,
     totalItems: 0,
   })
   
-  const totalPage = Math.ceil(pageInfo.totalItems / pageInfo.itemPerPage);
+  const totalPage = Math.ceil(pageInfo.totalItems / pageInfo.itemPerPage)
   
   useEffect(() => {
-    window.addEventListener("scroll", handleScroll);
-    return () => window.removeEventListener("scroll", handleScroll);
-  });
+    window.addEventListener("scroll", handleScroll)
+    return () => window.removeEventListener("scroll", handleScroll)
+  })
 
   useEffect(() => {
-    setCurrPage(0);
-  }, [filterProduct, categories]);
+    setCurrPage(0)
+  }, [filterProduct, categories])
 
   const handleFilter = (selectedFilter: any) => setFilterProduct(selectedFilter)
   const resetFilter = () => router.replace(`/${lng}/products`)
@@ -126,18 +126,18 @@ const ProductsPage: FC<any> = ({
   const handleScroll = () => {
     const lastItem = document.querySelector(
       ".products_container:last-of-type"
-    ) as HTMLElement;
+    ) as HTMLElement
 
     if (lastItem) {
-      const lastItemOffset = lastItem.offsetTop + lastItem.clientHeight;
-      const pageOffset = window.pageYOffset + window.innerHeight;
-      if (pageOffset > lastItemOffset && currPage < totalPage - 1) setCurrPage(currPage + 1);
+      const lastItemOffset = lastItem.offsetTop + lastItem.clientHeight
+      const pageOffset = window.pageYOffset + window.innerHeight
+      if (pageOffset > lastItemOffset && currPage < totalPage - 1) setCurrPage(currPage + 1)
     }
-  };
+  }
 
   const scrollToTop = () => {
-    document.body.scrollTop = 0; // For Safari
-    document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE and Opera
+    document.body.scrollTop = 0 // For Safari
+    document.documentElement.scrollTop = 0 // For Chrome, Firefox, IE and Opera
   }
 
   type TProductsProps = {

--- a/public/scss/components/ProductsComponent.module.scss
+++ b/public/scss/components/ProductsComponent.module.scss
@@ -175,6 +175,12 @@
   &_showResetContainer
   {
     display: none;
+
+    &--productsHighlight
+    {
+      display: block;
+      margin-bottom: 42px;
+    }
   }
 
 

--- a/public/scss/pages/Products.module.scss
+++ b/public/scss/pages/Products.module.scss
@@ -15,3 +15,11 @@
     }
   }
 }
+
+.productsHighlight
+{
+  &_breadcumb
+  {
+    margin-bottom: 24px;
+  }
+}

--- a/public/scss/pages/Products.module.scss
+++ b/public/scss/pages/Products.module.scss
@@ -2,14 +2,14 @@
 
 .products
 {
-  &_breadcumb
+  &_breadcrumb
   {
     margin-bottom: 42px;
   }
 
   @media (max-width: #{$breakpoint_min_sm}) 
   {
-    &_breadcumb
+    &_breadcrumb
     {
       margin-bottom: 24px;
     }
@@ -18,7 +18,7 @@
 
 .productsHighlight
 {
-  &_breadcumb
+  &_breadcrumb
   {
     margin-bottom: 24px;
   }


### PR DESCRIPTION
## Summary
Original task: https://phabricator.sirclo.com/T41721
- Bump nexus to 2.17.4
- Implement `products/[slug].tsx` page
- Enable show products amount ("menampilkan xx hasil")

## Screenshots
### Desktop
![image](https://user-images.githubusercontent.com/68508069/203722172-9d21b440-950d-45d6-b5e7-dbea0ec93a36.png)
![image](https://user-images.githubusercontent.com/68508069/203724099-35a20dcc-86e6-4f05-b8ce-b5784d69a2a6.png)

### Mobile
![image](https://user-images.githubusercontent.com/68508069/203724645-7ccb10f8-338b-4f0f-a588-9d1da5532efa.png)
![image](https://user-images.githubusercontent.com/68508069/203724695-b942ab0c-98c3-4de7-86f3-6def67a99a04.png)

### Access Token
![image](https://user-images.githubusercontent.com/68508069/203761522-c11a8bab-e50b-44cb-8175-4eeb58018ad9.png)
