### PR TITLE
fix(product-detail): increase image quality and size

### DIFF
--- a/components/ProductDetail/index.tsx
+++ b/components/ProductDetail/index.tsx
@@ -6,6 +6,8 @@ import { ProductDetail, ProductReviews } from '@sirclo/nexus'
 
 /* library component */
 import useProductDetail from './hooks/useProductDetail'
+import useWindowSize from 'lib/useWindowSize'
+import { useSizeBanner } from 'lib/useSizeBanner'
 
 /* components */
 import Placeholder from 'components/Placeholder'
@@ -165,6 +167,7 @@ const ProductDetailComponent: FC<IProps> = ({
 }) => {
 
   const router = useRouter()
+  const size = useWindowSize();
   const [showReview, setShowReview] = useState<boolean>(true)
   const [totalReviews, setTotalReviews] = useState<number>(0)
 
@@ -250,9 +253,9 @@ const ProductDetailComponent: FC<IProps> = ({
           1: true,
         }}
         thumborSetting={{
-          width: 800,
+          width: useSizeBanner(size.width),
           format: "webp",
-          quality: 85,
+          quality: 100,
         }}
         customDetailComponent={
           <>

--- a/lib/useSizeBanner.ts
+++ b/lib/useSizeBanner.ts
@@ -8,8 +8,7 @@ export const useSizeBanner = (width: number): number => {
   else if (width > 991 && width < 1200) output = 1296
   else if (width > 767 && width < 992) output = 1080
   else if (width > 575 && width < 768) output = 900
-  else if (width > 479 && width < 576) output = 720
-  else if (width < 480) output = 540
+  else if (width < 576) output = 800
 
   return output
 }


### PR DESCRIPTION
**Problem :** 
Resolusi Image Tidak Tajam di Product Detail Page Template Urban

**Before**
<img width="1280" alt="Screen Shot 2022-12-19 at 16 01 19" src="https://user-images.githubusercontent.com/43097333/208387997-2c5206e1-1ccb-40f0-9d0a-a20835892d43.png">

**After**
<img width="1280" alt="Screen Shot 2022-12-19 at 15 59 05" src="https://user-images.githubusercontent.com/43097333/208388029-3c962b77-cbea-4123-9c95-7eae994f21c7.png">

