### PR TITLE
fix(account): Wrap long text in product title

### DIFF
--- a/public/scss/pages/Account.module.scss
+++ b/public/scss/pages/Account.module.scss
@@ -1420,6 +1420,11 @@
   {
     @include RegulerReguler;
     margin-bottom: 8px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
   }
 
   &_orderedItemDetailPrice


### PR DESCRIPTION
Task:  https://phabricator.sirclo.com/T40001

**Feedback UI/UX: kondisi title nya panjang dijadikan 2 lines seperti ini**  
design:
![image (35)](https://user-images.githubusercontent.com/16263184/216887924-2557c6a7-db8c-4aab-9a69-148684223541.png)
**before:** 
![Urban Theme - Akun Saya - Google Chrome 06_02_2023 11_57_55](https://user-images.githubusercontent.com/16263184/216888059-e40fbe95-d0ec-4b32-b3d6-8177af7a8654.png)
**after:** 
![Urban Theme - Akun Saya - Google Chrome 06_02_2023 11_57_25](https://user-images.githubusercontent.com/16263184/216888087-c6bc19bf-1b11-4902-89ca-4bcda500e287.png)
![Toko Online Dekorasi   Furniture Rumah Modern - Lumikasa - Akun Saya - Google Chrome 06_02_2023 13_46_47](https://user-images.githubusercontent.com/16263184/216902005-5946423c-8ad0-4317-ad92-7b89964946a6.png)
![File (13)](https://user-images.githubusercontent.com/16263184/216902423-848d64ea-dfaa-44a1-8d5e-d7f214e1c1ad.jpg)


