### PR TITLE
fix: bump ver 2.19.2 and fix custom shipping when value 0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@elgorditosalsero/react-gtm-hook": "^2.4.0",
-    "@sirclo/nexus": "2.19.0",
+    "@sirclo/nexus": "2.19.2",
     "bootstrap": "^4.5.0",
     "cookie": "^0.4.1",
     "env-cmd": "^10.1.0",


### PR DESCRIPTION
- Fix discountedCost.value undefined in Custom Shipping (2.19.1)
- fix: remove unwanted "0" from Price Breakdown in Order Summary (2.19.2)

| Custom Shipping 0  | ![image](https://github.com/sirclo-solution/template-urban/assets/38358288/2ff6c703-17f9-448b-a722-bd706556470d) |
| Custom Shipping not 0 | ![image](https://github.com/sirclo-solution/template-urban/assets/38358288/59ae19a2-a40f-4f1d-952e-c6d32a0b0547) |
| Normal Indonesia Shipping  | ![image](https://github.com/sirclo-solution/template-urban/assets/38358288/6b1ae62f-a77e-4fb1-9017-ea7876f0649f)  |
| Thank You Page  | ![image](https://github.com/sirclo-solution/template-urban/assets/38358288/cc9da70e-6d47-41c6-afd7-ff57b9db96a9)  | 
| Order History  | 
![image](https://github.com/sirclo-solution/template-urban/assets/38358288/8ee1fc0d-ee0b-4e4d-9b85-f49d2e390470)
  | 