### PR TITLE
chore: bump to 2.19.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@elgorditosalsero/react-gtm-hook": "^2.4.0",
-    "@sirclo/nexus": "2.19.5",
+    "@sirclo/nexus": "2.19.7",
     "bootstrap": "^4.5.0",
     "cookie": "^0.4.1",
     "env-cmd": "^10.1.0",


### PR DESCRIPTION
Template is running well:
![Screenshot from 2023-06-12 13-21-43](https://github.com/sirclo-solution/template-urban/assets/40454642/92e08f57-8cb5-4813-bc22-6e107eb44ed6)