### PR TITLE
chore: bump version nexus 2.19.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@elgorditosalsero/react-gtm-hook": "^2.4.0",
-    "@sirclo/nexus": "2.19.7",
+    "@sirclo/nexus": "2.19.9",
     "bootstrap": "^4.5.0",
     "cookie": "^0.4.1",
     "env-cmd": "^10.1.0",


### PR DESCRIPTION
Task: [[Urban] Bump version nexus 2.19.9](https://phabricator.sirclo.com/T50385)

**Local build aman**
![image](https://github.com/sirclo-solution/template-urban/assets/16263184/66ec9c37-fb43-4fd7-9402-2b60bec6962b)

test di site id test-merlin
**fix product stock minus: **
![image](https://github.com/sirclo-solution/template-framic/assets/16263184/5d2ecc44-d3bf-4334-b763-d50945e33568)
![image](https://github.com/sirclo-solution/template-urban/assets/16263184/78581da2-c81f-4d42-8602-a58974d9f35e)

